### PR TITLE
fix(#34): downgrade foojay-resolver plugin version to resolve build failure

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@
 
 plugins {
     // Apply the foojay-resolver plugin to allow automatic download of JDKs
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.10.0'
 }
 
 rootProject.name = 'jmh-benchmark-action'


### PR DESCRIPTION
This PR updates the `foojay-resolver` plugin version in `settings.gradle` to resolve build failures related to JVM compatibility.

Related to #34