### PR TITLE
ci(#34): update Java version from 17 to 11 in GitHub Actions workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,11 +15,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
-      - name: Set up JDK 17
+      - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '11'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Grant execute permission for gradlew


### PR DESCRIPTION
This PR updates the Java version in the `tests.yml` workflow from `17` to `11` to resolve build failures related to the `foojay` dependency.

Related to #34